### PR TITLE
correct german translation for the state "despair" of a hunter

### DIFF
--- a/lang/de/hunter-de.json
+++ b/lang/de/hunter-de.json
@@ -8,7 +8,7 @@
       "HunterDice": "Jäger-Würfel",
       "DesperationDice": "Verzweiflungs-Würfel",
 
-      "Despair": "Verzweiflung",
+      "Despair": "Hoffnungslosigkeit",
       "Creed": "Überzeugung",
       "CreedFields": "Einsatzgebiete der Überzeugungen",
       "Cell": "Zelle",


### PR DESCRIPTION
the state got an errata in german, this pull request corrects the translation according to the new german one