### PR TITLE
[FEATURE] #201 WTA: Autoshift to crinos on frenzy 

### DIFF
--- a/system/actor/wta/scripts/frenzy.js
+++ b/system/actor/wta/scripts/frenzy.js
@@ -9,6 +9,9 @@ export const _onBeginFrenzy = async function (event) {
 
   // Set rage to 5
   await actor.update({ 'system.rage.value': 5 })
+
+  // Shift to Crinos
+  await actor.update({ 'system.activeForm': 'crinos' })
 }
 
 export const _onEndFrenzy = async function (event) {


### PR DESCRIPTION
Tested locally, shifts without rage checks on entering frenzy as per the Corebook rules.
Leaving frenzy still trigges form choice dialog windows for losing the wolf.
https://github.com/WoD5E-Developers/wod5e/issues/201