### PR TITLE
[Bug] #157 frenzy modifier bugging out

### DIFF
--- a/system/scripts/system-rolls.js
+++ b/system/scripts/system-rolls.js
@@ -472,8 +472,8 @@ class WOD5eDice {
                   })
                 })
               })
-              
-              //Apply modifier at the start of the dialog window
+
+              // Apply modifier at the start of the dialog window
               dialogHTML.querySelectorAll('.mod-checkbox').forEach(checkbox => {
                 checkbox.dispatchEvent(new Event('change'))
               })

--- a/system/scripts/system-rolls.js
+++ b/system/scripts/system-rolls.js
@@ -266,7 +266,7 @@ class WOD5eDice {
 
                   // Obtain the input fields
                   const basicDiceInput = dialogHTML.querySelector('#inputBasicDice')
-                  const advancedDiceInput = dialogHTML.querySelector('#inputAdvancedDice') 
+                  const advancedDiceInput = dialogHTML.querySelector('#inputAdvancedDice')
 
                   // Get the values
                   let basicValue = basicDiceInput ? basicDiceInput?.value : 0

--- a/system/scripts/system-rolls.js
+++ b/system/scripts/system-rolls.js
@@ -357,15 +357,18 @@ class WOD5eDice {
                   // Either use the current applyDiceTo (if set), or default to 'basic'
                   let applyDiceTo = event.currentTarget.dataset.applyDiceTo || 'basic'
 
-                  if (modifierIsNegative) {
-                    // Apply dice to basicDice unless basicDice is 0
-                    if ((system === 'vampire' || system === 'werewolf') && basicValue === 0) {
-                      applyDiceTo = 'advanced'
-                    }
-                  } else {
-                    // Apply dice to advancedDice if advancedValue is below the actor's hunger/rage value
-                    if ((system === 'vampire' && advancedValue < actorData?.hunger.value) || (system === 'werewolf' && advancedValue < actorData?.rage.value)) {
-                      applyDiceTo = 'advanced'
+                  // Make sure advanced dice are enabled
+                  if (!disableAdvancedDice) {
+                    if (modifierIsNegative) {
+                      // Apply dice to basicDice unless basicDice is 0
+                      if ((system === 'vampire' || system === 'werewolf') && basicValue === 0) {
+                        applyDiceTo = 'advanced'
+                      }
+                    } else {
+                      // Apply dice to advancedDice if advancedValue is below the actor's hunger/rage value
+                      if ((system === 'vampire' && advancedValue < actorData?.hunger.value) || (system === 'werewolf' && advancedValue < actorData?.rage.value)) {
+                        applyDiceTo = 'advanced'
+                      }
                     }
                   }
 

--- a/system/scripts/system-rolls.js
+++ b/system/scripts/system-rolls.js
@@ -266,7 +266,7 @@ class WOD5eDice {
 
                   // Obtain the input fields
                   const basicDiceInput = dialogHTML.querySelector('#inputBasicDice')
-                  const advancedDiceInput = dialogHTML.querySelector('#inputAdvancedDice')
+                  const advancedDiceInput = dialogHTML.querySelector('#inputAdvancedDice') 
 
                   // Get the values
                   let basicValue = basicDiceInput ? basicDiceInput?.value : 0
@@ -284,7 +284,6 @@ class WOD5eDice {
                       basicValue = Number(basicValue || 0) + value
                     })
                   }
-
                   // Send the roll to the _roll function
                   roll = await _roll(basicValue, advancedValue, html)
                 }
@@ -303,7 +302,8 @@ class WOD5eDice {
 
               // Obtain the input fields for basic and advanced dice
               const basicDiceInput = dialogHTML.querySelector('#inputBasicDice')
-              const advancedDiceInput = dialogHTML.querySelector('#inputAdvancedDice')
+              // Null coalescing and default value added for rolls without advanced dies like frenzy check for vampires
+              const advancedDiceInput = dialogHTML.querySelector('#inputAdvancedDice') ?? { value: 0 }
 
               // Add event listeners to plus and minus signs on the dice in the dialog
               dialogHTML.querySelectorAll('.dialog-plus').forEach(function (el) {
@@ -471,6 +471,11 @@ class WOD5eDice {
                     })
                   })
                 })
+              })
+              
+              //Apply modifier at the start of the dialog window
+              dialogHTML.querySelectorAll('.mod-checkbox').forEach(checkbox => {
+                checkbox.dispatchEvent(new Event('change'))
               })
             }
           },

--- a/system/scripts/system-rolls.js
+++ b/system/scripts/system-rolls.js
@@ -301,8 +301,8 @@ class WOD5eDice {
               const dialogHTML = html[0]
 
               // Obtain the input fields for basic and advanced dice
-              const basicDiceInput = dialogHTML.querySelector('#inputBasicDice')
-              // Null coalescing and default value added for rolls without advanced dies like frenzy check for vampires
+              // In case of null, default either value to 0
+              const basicDiceInput = dialogHTML.querySelector('#inputBasicDice') ?? { value: 0 }
               const advancedDiceInput = dialogHTML.querySelector('#inputAdvancedDice') ?? { value: 0 }
 
               // Add event listeners to plus and minus signs on the dice in the dialog
@@ -471,11 +471,6 @@ class WOD5eDice {
                     })
                   })
                 })
-              })
-
-              // Apply modifier at the start of the dialog window
-              dialogHTML.querySelectorAll('.mod-checkbox').forEach(checkbox => {
-                checkbox.dispatchEvent(new Event('change'))
               })
             }
           },


### PR DESCRIPTION
First issue was with advanced die input null error due to input not exsisting for frenzy test this prevented modifier checkbox event code from working, then there was an issue of modifier not being applied on loading the window.
Tested on dev
https://github.com/WoD5E-Developers/wod5e/issues/157