### PR TITLE
Fix possible issue with file-picking via actor sheets

### DIFF
--- a/system/item/scripts/on-edit-image.js
+++ b/system/item/scripts/on-edit-image.js
@@ -6,7 +6,7 @@ export const _onEditImage = async function (event) {
   // Top-level variables
   const item = this.item
 
-  new foundry.applications.apps.FilePicker({
+  await new foundry.applications.apps.FilePicker({
     type: 'image',
     current: item.img,
     callback: async (path) => {


### PR DESCRIPTION
I think this might be the issue from Discord.
The foundry code that fails is probably this:
```el.parentElement.offsetWidth```

Which means it has a problem finding the parent element of the current ApplicationV2 element.
This might happen if we don't await the browser action, and other things happen that remove that element from the DOM.