### PR TITLE
chore: fix typo on crinos health (PT-BR localization)

### DIFF
--- a/lang/pt-BR/werewolf-pt-BR.json
+++ b/lang/pt-BR/werewolf-pt-BR.json
@@ -17,7 +17,7 @@
       "CrinosBite": "Mordida: +1 Agravado",
       "CrinosClaws": "Garras: +3",
       "CrinosFrenzy": "Risco de Frenesi, 1 Força de Vontade/turno",
-      "CrinosHealth": "Vitalidaed: +4",
+      "CrinosHealth": "Vitalidade: +4",
       "CrinosName": "Crinos",
       "CrinosPhysicalTests": "Testes Físicos: +4",
       "CrinosRegenerate": "Regeneração: 2/Checagem de Fúria",


### PR DESCRIPTION
There was a typo on Crinos Health description in PT-BR localization.

"Vitalidaed" -> "Vitalidade"