### PR TITLE
Fix stretched member thumbnails on the group sheet

### DIFF
--- a/display/shared/styling/parts/group-sheets.less
+++ b/display/shared/styling/parts/group-sheets.less
@@ -98,6 +98,8 @@
           border: 1px solid;
           margin: 0 3px;
           cursor: pointer;
+          object-fit: cover;
+          object-position: 50% 0;
         }
       }
 

--- a/display/wod5e-styling.css
+++ b/display/wod5e-styling.css
@@ -2265,6 +2265,8 @@ body.uk .actor.sheet {
   border: 1px solid;
   margin: 0 3px;
   cursor: pointer;
+  object-fit: cover;
+  object-position: 50% 0;
 }
 .group.sheet .tab[data-tab="members"] .group-member .sub-item.werewolf-form {
   float: inline-end;


### PR DESCRIPTION
Member portraits on the group sheet render at a fixed 50x50 with no `object-fit`, so the
browser falls back to `fill` and distorts anything that is not already square.

Aligns them with how core renders the sidebar directory:

```css
.directory .directory-item img {
  object-fit: cover;
  object-position: 50% 0;
}
```

`50% 0` keeps the top of the portrait, where faces usually are, and crops the bottom.

CSS rebuilt with `gulp less`; the only changes are the two lines.